### PR TITLE
Updated Actobotics Wiki Page

### DIFF
--- a/building/building-systems/actobotics.md
+++ b/building/building-systems/actobotics.md
@@ -1,24 +1,253 @@
-# Actobotics #
+# Actobotics
+*go back to [/r/FTC wiki](/r/FTC/wiki)*
+
+__This article is up to date as of Dec 07, 2017.__
+
+&nbsp;
 
 Actobotics is a construction set distributed by ServoCity: http://servocity.com. 
 It is similar to Tetrix, but the channels are slightly larger (cross-section of 1.5x1.5 in, or approximately 39x39 mm, 
 as opposed to 32x32 mm for Tetrix), and the hole pattern is more complicated. 
 
 
-Actobotics provides much wider choice of components than Tetrix, in particular 
-offering stronger axles, ball bearings, servo mounts and more. 
-ServoCity offers a 25% discount to all FTC teams, which is a great deal; in addition, they provide limited number of sponsorships to FTC teams every year. To find out more, visit  https://www.servocity.com/first
+Actobotics provides a much wider choice of components than Tetrix, in particular offering stronger axles, ball bearings, servo mounts and more. 
+ServoCity offers a 25% discount to all FTC teams, which is a great deal; in addition, they provide a limited number of sponsorships to FTC teams every year. To find out more, visit  their [FIRST Hub](https://www.servocity.com/first)
 
 
-The best way to get started with Actobotics is by getting their  [FTC competition kit](https://www.servocity.com/ftc-competition-kit). As of December 2017, the price is $479.99 after FTC discount. The kit  comes with a choice of motors; most teams would need four NeveRest 40 motors.
+The best way to get started with Actobotics is by getting their  [FTC competition kit](https://www.servocity.com/ftc-competition-kit). As of December 2017, the price is $479.99 after FTC discount. The kit comes with a choice of motors; most teams would need four NeveRest 40 motors.
 
 
 Actobotics hole pattern is not compatible with Tetrix, but there are [adapters](https://www.servocity.com/hub-adaptor-b) allowing one to connect Actobotics to Tetrix.
 
-## Channels and Beams ##
+## Structural Components ##
+### Actobotics Hole Patterns - ([link](https://www.servocity.com/hole-pattern-information)) ###
+There are a number of hole patterns, or spacing of pre-drilled and pre-tapped holes, used in COTS building systems. Actobotics primarily uses the 0.770" hole pattern. Some parts also support the 1.50" hole pattern.
 
-## Axles, hubs, bearings ##
+You can see more detailed information about hole patterns [here](https://www.servocity.com/hole-pattern-information).
 
-## ServoBlocks ##
+### Standard Channel - ([link](https://www.servocity.com/structural-components/channel)) ###
+The primary structural component in Actobotics robots/mechanisms is the Standard Channel. These are Aluminum U-Channels with the Actobotics Hole pattern (detailed above) pre-drilled into them, coming in a wide variety of lengths, from 1.5" to 48". Many of Actobotics' components are designed to fit on or in the channels, which makes building in the Actobotics ecosystem easy. The channel uses 0.770" and 1.50" hole patterns repeating across the length of the channel on all three sides.
 
-## Cascading Rail slide ##
+Property | Value
+:--|:--
+Length | 1.5-48"
+Width | 1.5"
+Height | 1.5"
+Inside Width | 1.32"
+Wall Thickness | 0.09"
+Pattern Spread | 0.75"
+
+Channels can be connected to each other in a number of ways, but the most recommended way is to use the [Side Tapped Pattern Mount C](https://www.servocity.com/90-quad-hub-mount-c). More information about this product can be found below or on its product page.
+
+### Mini Channel - ([link](https://www.servocity.com/structural-components/channel/mini-channel)) ###
+Actobotics Mini Channel is similar to Standard Channel, but smaller and without most of the holes. It can also be used in building your robot, but it may not be suitable for most mechanisms. The channel only has one pattern of holes, spaced at half of the 0.770" hole pattern (therefore it is compatible with 0.770" patterns). This pattern is along the length of the channel on all three sides. Actobotics Beams will fit just inside the mini channel, making a great combination for unfolding mechanisms.
+
+Property | Value
+:--|:--
+Length | 0.375"-12.32"
+Width | 0.370"
+Height | 0.585"
+Inside Width | 0.25"
+Wall Thickness | 0.06"
+Pattern Spread | 0.385"
+
+### X-Rail - ([link](https://www.servocity.com/x-rail)) ###
+Stub
+
+### Aluminum Box Extrusion - ([link](https://www.servocity.com/aluminum-box-extrusion)) ###
+Actobotics sells a small selection of Box Extrusion. It is a good deal, too, at about half the price of similar extrusions from McMaster. The box extrusion has a 0.09" wall thickness to match other Actobotics products, making it compatible with most of the products compatible with Actobotics Channels. For example, products such as the [Side Tapped Pattern Mount C](https://www.servocity.com/90-quad-hub-mount-c) can fit inside the 1.5x1.5 channel.
+
+However, since Box Extrusion comes with no holes pre-drilled, this product is not recommended for teams who have no machining experience. While it is not recommended for teams without some machining experience, the Box Extrusion can be put to good use with simple hand tools.
+
+Property | 1x1 | 1x1.5 | 1.5x1.5
+:--|:--|:--|:--
+Length | 6' | 6' | 6'
+Width | 1.0" | 1.0" | 1.5"
+Height | 1.0" | 1.5" | 1.5"
+Inside Width | 0.82" | 0.82" | 1.32"
+Inside Height | 0.82" | 1.32" | 1.32"
+Wall Thickness | 0.09" | 0.09" | 0.09"
+
+### Beams - ([link](https://www.servocity.com/structural-components/beams)) ###
+Actobotics Beams are small and easy to use for various support or mechanism applications. The beams follow the same half-0.770" hole pattern as Mini Channel. Beams are sold in Aluminum and Plastic. While both selections have the same range in lengths, the plastic beams have more variety in pre-cut lengths. The beams also have a thickness of 0.25", the same as the inside width of the Mini channel, so the beams fit nicely in Mini Channel, making a great combination for unfolding mechanisms.
+
+Property | Value
+:--|:--
+Length | 1.54"-12.32"
+Width | 0.25"
+Height | 0.375"
+Pattern Spread | 0.385"
+
+There is also a large selection of [Beam Brackets](https://www.servocity.com/structural-components/beams/beam-brackets) that can be used to join beams. Most brackets are plastic, but will work the same on plastic and aluminum beams.
+
+### Pattern Plates - ([link](https://www.servocity.com/structural-components/pattern-plates)) ###
+Actobotics pattern plates are flat plates 0.09" thick that have the same pattern as the Channel repeated across their surface. These can be used for structural support, mechanisms, and plates to mount other robot parts to.
+
+Property | Value
+:--|:--
+Length | 2.25"-12.0"
+Width | 1.50"-9"
+Thickness | 0.09"
+Pattern Spread | 0.75"
+
+### Pattern Brackets - ([link](https://www.servocity.com/structural-components/pattern-brackets)) ###
+Actobotics sells a wide variety of brackets with the channel pattern pre-drilled. Many can be used to support structural components, and it's usually a good idea to have a few [90° Single Angle Pattern Brackets]() and [Flat Single Pattern Bracket]() laying around, as they come in handy from time to time.
+
+It is important to note, however, that 90° Angle Pattern Brackets are not recommended for use in mating two Channels unless absolutely necessary, as the [Side Tapped Pattern Mount C](https://www.servocity.com/90-quad-hub-mount-c) will fit better and be much more rigid.
+
+### Pattern Mounts - ([link](https://www.servocity.com/structural-components/pattern-mounts)) | Side Mounts - ([link](https://www.servocity.com/structural-components/side-mounts)) ###
+Pattern and Side Mounts are compatible with the Channel patterns and used to attach channels and other structural components. Check out the product pages to see which part will fit your specific application. The [90° Angle Bracket](https://www.servocity.com/90-angle-bracket-a) is also noteworthy as it allows you to create rigid connections.
+
+### Side Tapped Pattern Mount C - ([link](https://www.servocity.com/90-quad-hub-mount-c)) ###
+This is possibly one of the most important Actobotics parts. This product can be used to mate two channels in an incredibly rigid connection that is highly recommended for robot structural components. It provides a number of tapped holes to mount with, so no nuts are required to mate channels, making it easy to use. Teams should always have some of these around, and while they aren't the cheapest part, they will make your robot much more robust.
+
+### Clamping Mounts - ([link](https://www.servocity.com/structural-components/clamping-mounts/bottom-tapped-clamping-mounts)) ###
+Clamping mounts can be used to mount a variety of shafts to channels. Among other sizes, you can use quarter inch clamping mounts with Servocity's 1/4" D Shaft to mount a shaft inside a channel.
+
+Additionally, the [37mm Bore Bottom Tapped Clamping Mount](https://www.servocity.com/37mm-clamping-motor-mount) can be used to mount Neverest motors to channels. Some teams choose to use two of these mounts per Neverest to increase rigidity and prevent motor slipping.
+
+### ServoBlocks ###
+ServoBlocks are incredible for making servo-powered mechanisms durable. Servoblocks will mount to Actobotics patterns easily and convert the servo's spline to a bearing supported 0.770" hub. Servoblock variations are available for [Hitec Servos](https://www.servocity.com/637110), [Rev/Futaba Servos](https://www.servocity.com/637112), and [Hitec Quarter Scale Servos](https://www.servocity.com/637118). It is highly recommended that you give this product a shot.
+
+### Standoffs - ([link](https://www.servocity.com/structural-components/standoffs-spacers/standoffs)) ###
+Actobotics sells a variety of standoffs, but the most useful ones are the [6-32 Thread, 1/4" OD Round Aluminum Standoffs](https://www.servocity.com/6-32-thread-1-4-od-round-aluminum-standoffs). The quarter inch diameter lets them fit inside the same bearings the Actobotics 1/4" D Shaft does, and they can easily be screwed into any hole in the pattern. They come in a variety of lengths to match your use, but the 1.32" length is noteworthy because it matches the inside width of the Standard Channel. These can be used to tension chains or belts, or to add structural support to the channel.
+
+Property | Value
+:--|:--
+Length | 0.25"-3.0"
+Diameter | 0.25"
+Thread Depth | 0.3"
+
+&nbsp;
+
+## Axles, Hubs, and Bearings ##
+### Shafts - ([link](https://www.servocity.com/shafting-tubing/shafting)) ###
+Actobotics sells many Shaft options, but the primary shaft is the [1/4" Stainless Steel D-Shafting](https://www.servocity.com/0-250-1-4-stainless-steel-d-shafting). These D-Shafts have one side flattened for set screws to bite down on.
+
+Property | Value
+:--|:--
+Length | 1.0"-12.0"
+Diameter | 0.25"
+
+### Couplers - ([link](https://www.servocity.com/shafting-tubing/couplers)) ###
+Actobotics sells a variety of shaft couplers that can be used to mate two shafts. Most notable are the [0.25"-6mm and 0.25"-0.25" Set Screw Shaft Coupler](https://www.servocity.com/set-screw-shaft-couplers), which can be used to mate Neverest output shafts (6mm) to Servocity Shafts and Servocity shafts to Servocity shafts, respectively.
+
+### Hubs - ([link](https://www.servocity.com/motion-components/rotary-motion/hubs)) ###
+While there are many hub options, the most relevant are the 0.770" Pattern Set Screw Hubs. These come in two flavors - [Regular](https://www.servocity.com/770-set-screw-hubs) and [D Bore](https://www.servocity.com/0-770-set-screw-d-hubs). The D Bore hubs are slightly more expensive, but will not experience the slipping issue that the regular hubs do. Both of these hubs adhere to the 0.770" hole pattern, so they are compatible with other Actobotics parts.
+
+### Bearings - ([link](https://www.servocity.com/motion-components/rotary-motion/bearings-bushings)) ###
+Actobotics sells a huge variety of bearings. Compared to bushings, ball bearings are much smoother and have less friction. The [1/4" ID x 1/2" OD Flanged Ball Bearings](https://www.servocity.com/0-250-id-x-0-500-od-flanged-ball-bearing) are your best friend. These bearings fit in the 0.5" holes that repeat every 0.75" on the Channel and support the 0.25" D shafting.
+
+The [Ball Bearing Idler Shaft](https://www.servocity.com/ball-bearing-idler-shaft-a) is also useful for tensioning chains and belts. The product page lists which components you need to mount it.
+
+[Pillow Blocks](https://www.servocity.com/motion-components/rotary-motion/bearings-bushings/pillow-blocks) are also nice for some applications. The [Bottom](https://www.servocity.com/250-pillow-block) and [Side](https://www.servocity.com/250-bore-quad-pillow-block) tapped pillow blocks for the 0.25" D shaft are most applicable, though others are available.
+
+### Collars - ([link](https://www.servocity.com/steel-set-screw-collars)) ###
+Actobotics' collar selection includes 1/4" collars that can be used for Actobotics D Shaft. Aluminum collars are also available (yes, they are lighter), but are much more expensive.
+
+&nbsp;
+
+## Gears, Sprockets, and Belts ##
+Gears, Sprockets, and Belts are the primary way by which we transfer power from one shaft to another. Gears and belts loose less power than chain, but require more precise spacing to function.
+
+### Gears - ([link](https://www.servocity.com/motion-components/rotary-motion/gears)) ###
+Actobotics sells a huge variety of gears that are compatible with their shafts and hubs. Read the wiki page on gears to make sure you buy the right ones.
+
+[1/2" Bore 32 Pitch Aluminum Hub Gears](https://www.servocity.com/32-pitch-50-bore-aluminum-hub-gears) are to be mounted to the 0.770" hubs and come in sizes from 48-84 teeth. Gears are 1/4" wide with the interior milled down to 1/8" to save wight.
+
+Teeth | Pitch Diameter
+:--|:--
+48T | 1.500"
+64T | 2.000"
+72T | 2.250"
+76T | 2.375"
+80T | 2.500"
+84T | 2.625"
+
+[1.00" Bore 32 Pitch Aluminum Hub Gears](https://www.servocity.com/32p-1-00-bore-aluminum-hub-gears) can't be mounted directly to 0.770" hubs, but the [1.50"-0.770" Pattern Adapter](https://www.servocity.com/hub-adaptor-d) can mount between the gear and the hub to accomplish this. Gears are 1/4" wide with the interior milled down to 1/8" to save wight.
+
+Teeth | Pitch Diameter
+:--|:--
+76T | 2.375"
+84T | 2.625"
+128T | 4.000"
+
+[32 Pitch Shaft Mount Pinion Gears](https://www.servocity.com/motion-components/rotary-motion/gears/shaft-mount-pinion-gears/32-pitch-shaft-mount-pinion-gears) can mount directly to a variety of shafts and are compatible with the Hub gears. Use a [1/4" Bore](https://www.servocity.com/0-250-1-4-bore-32p-shaft-mount-pinion-gears) to mount on an Actobotics D-Shaft and use a [6mm Bore](https://www.servocity.com/6mm-bore-32p-shaft-mount-pinion-gears) to mount on a Neverest Motor.
+
+Teeth | Pitch Diameter
+:--|:--
+16T | 0.500"
+20T | 0.625"
+24T | 0.750"
+32T | 1.000"
+
+[Bevel Gears](https://www.servocity.com/motion-components/rotary-motion/gears/shaft-mount-bevel-gears) are also available for both [6mm](https://www.servocity.com/6mm-bevel-gears) Neverest shafts and [1/4"](https://www.servocity.com/250-bore-bevel-gears) Actobotics D-Shaft. Bevel gears can be used to change the direction of rotation. Note that the 24 tooth bevel gears need to be used with another 24 tooth bevel gear and the 16 tooth bevel gear needs to be used with a 32 tooth bevel gear.
+
+Bore | Teeth | Compatible With
+:--|:--
+6mm | 16T | 32T
+6mm | 24T | 24T
+1/4" | 16T | 32T
+1/4" | 24T | 24T
+1/4" | 32T | 16T
+
+### Sprockets - ([link](https://www.servocity.com/motion-components/rotary-motion/sprockets-chain/sprockets/hub-mount-sprockets)) ###
+Sprockets are used to transfer motion through roller chain. Read the wiki page on sprockets to make sure you know what you need to have to use chains.
+
+Actobotics' sprocket selection ranges from 16-48 teeth. The sprockets are all .1" thick and use standard 1/4" roller chain.
+
+[1/2" Bore 0.250" Pitch Aluminum Hub Sprockets](https://www.servocity.com/0-770-aluminum-hub-mount-sprockets-0-250-pitch) are to be mounted to the 0.770" hubs and come in sizes from 16-32 teeth.
+
+Teeth | Pitch Diameter
+:--|:--
+16T | 1.282"
+24T | 1.955"
+32T | 2.551"
+
+[1" Bore 0.250" Pitch Aluminum Hub Sprockets](https://www.servocity.com/1-50-aluminum-hub-mount-sprockets-0-250-pitch) can't be mounted directly to 0.770" hubs, but the [1.50"-0.770" Pattern Adapter](https://www.servocity.com/hub-adaptor-d) can mount between the sprocket and the hub to accomplish this.
+
+Teeth | Pitch Diameter
+:--|:--
+40T | 3.188"
+48T | 3.823"
+
+### Belts - ([link](https://www.servocity.com/motion-components/rotary-motion/pulleys-belts/timing-pulleys-belts)) ###
+Pulleys and Belts are a good way to transfer motion through timing belts. Timing belts are fixed length with teeth on the inside. Make sure to read the wiki page on belts to understand how to choose the right belt.
+
+Actobotics belts are XL profile, 3/8" wide, and 1/5" pitch. Actobotics sells the [3/8" Wide XL Timing Belts](https://www.servocity.com/0-375-3-8-wide-timing-belts) for tooth counts from 25-240, incrementing by 5 teeth. 
+
+[Timing Pinion Pulleys](https://www.servocity.com/motion-components/rotary-motion/pulleys-belts/timing-pulleys-belts/timing-pinion-pulleys) can mount directly to an Actobotics or Neverest shaft. The [15 Tooth Pinion Pulley](https://www.servocity.com/15-tooth-pinion-pulleys) can be used with Actobotics belts to match the hole pattern and can fit _inside_ a Standard Channel.
+
+&nbsp;
+
+## Wheels ##
+
+### Heavy Duty Wheels ###
+Actobotics Heavy Duty wheels come in [4"](https://www.servocity.com/4-heavy-duty-wheel) and [6"](https://www.servocity.com/6-heavy-duty-wheel) diameters. These wheels get good traction on the tiles and are robust enough for FTC. The 4" wheel can be mounted to a 0.770" hub, but the 6" wheel needs to use the [1.50"-0.770" Pattern Adapter](https://www.servocity.com/hub-adaptor-d).
+
+### Omni Wheels ###
+Actobotics' [Omni wheels](https://www.servocity.com/4-omni-wheel) can be mounted directly to 0.770" hubs. They are robust enough for FTC. [This image](https://www.servocity.com/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/5/9/595671-b_3.jpg) demonstrates mounting two of these wheels together with a hub, though instead of 545579 it may be a good idea to use the [D-Hub](https://www.servocity.com/0-770-set-screw-d-hubs) of your choice.
+
+&nbsp;
+
+## Linear Motion ##
+
+### Cascading X-Rail Slide - ([link](https://www.servocity.com/cascading-x-rail-slide-kit)) ###
+Stub
+
+### X-Rail V Rollers ###
+Stub
+
+### Linear Bearings ###
+Stub
+
+### Lead Screws ###
+Stub
+
+### Channel Sliders ###
+Stub
+
+&nbsp;
+
+*All content on this wiki is licensed under the [Creative Commons Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0/) liscense.*
+/r/FTC thanks you for reading this article and asks you to [contribute](https://github.com/GeekyStudios/rFTC-wiki) soon.


### PR DESCRIPTION
Initial set of information for the Actobotics Wiki Page.

Includes structural and motion components, missing linear motion information. This can be added later (and preferably by someone who has used some of these motion components before.